### PR TITLE
Do the marshalling / unmarshalling with implicit conversions

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,6 +15,7 @@ After cloning, the first thing you'll want to do before building and running the
 
 Once you obtain an API key, open GlobalConstants.scala and replace *putyourmoviedbapikeyhere* with your API key.
 
+If you want to import into Eclipse you must first oepn `sbt` then execute `>eclipse`.  This builds the Eclipse project files.
 
 The project builds and deploys to an embedded Jetty server using the [xsbt-web-plugin](https://github.com/JamesEarlDouglas/xsbt-web-plugin).
 

--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ After cloning, the first thing you'll want to do before building and running the
 
 Once you obtain an API key, open GlobalConstants.scala and replace *putyourmoviedbapikeyhere* with your API key.
 
-If you want to import into Eclipse you must first oepn `sbt` then execute `>eclipse`.  This builds the Eclipse project files.
+If you want to import into Eclipse you must first open `sbt` then execute `>eclipse`.  This builds the Eclipse project files.
 
 The project builds and deploys to an embedded Jetty server using the [xsbt-web-plugin](https://github.com/JamesEarlDouglas/xsbt-web-plugin).
 

--- a/src/main/scala/com/example/models/Movie.scala
+++ b/src/main/scala/com/example/models/Movie.scala
@@ -50,8 +50,8 @@ object MovieConstants {
   val POSTER_PATH_PREFIX_W500 = "http://d3gtl9l2a4fn1j.cloudfront.net/t/p/w500"
 }
 
-object MovieImplicits {
-  implicit def MovieDbToMovie(m: MovieDb): Movie = {
+object MovieConverter {
+  def toMovie(m: MovieDb): Movie = {
     Movie(m.id,
         m.title,
         m.release_date,
@@ -66,11 +66,10 @@ object MovieImplicits {
         m.tagline,
         m.spoken_languages
     )}
-  implicit def MovieDbOptionToMovieOption(mo: Option[MovieDb]): Option[Movie] = mo.map(MovieDbToMovie(_))
 }
 
-object MovieJsonProtocol extends DefaultJsonProtocol {
 
+object MovieJsonProtocol extends DefaultJsonProtocol {
   implicit val genresFormat = jsonFormat2(Genre)
   implicit val languageFormat = jsonFormat1(Language)
   implicit val MovieFormat = jsonFormat13(Movie)

--- a/src/main/scala/com/example/models/Movie.scala
+++ b/src/main/scala/com/example/models/Movie.scala
@@ -70,40 +70,6 @@ object MovieJsonProtocol extends DefaultJsonProtocol {
           fields.get("runtime").map(_.convertTo[Long]),
           fields.get("tagline").map(_.convertTo[String]),
           fields.get("spoken_languages").map(_.convertTo[List[Language]]))
-//      value.asJsObject.getFields("id", 
-//          "title", 
-//          "release_date",
-//          "poster_path",
-//          "overview",
-//          "budget",
-//          "genres",
-//          "revenue",
-//          "runtime",
-//          "tagline",
-//          "spoken_languages") match {
-//        case Seq(JsNumber(id), 
-//              JsString(title), 
-//              releaseDate, 
-//              posterPath,
-//              overview,
-//              budget,
-//              genres,
-//              revenue,
-//              runtime,
-//              tagline,
-//              spokenLanguages) =>
-//          new Movie(id.toLong, 
-//                title, 
-//                releaseDate.convertTo[Option[String]], 
-//                posterPath.convertTo[Option[String]],
-//                overview.convertTo[Option[String]],
-//                budget.convertTo[Option[Long]],
-//                genres.convertTo[Option[List[Genre]]],
-//                revenue.convertTo[Option[Long]],
-//                runtime.convertTo[Option[Long]],
-//                tagline.convertTo[Option[String]],
-//                spokenLanguages.convertTo[Option[List[Language]]])
-//      }
     }
   }
 }

--- a/src/main/scala/com/example/models/Movie.scala
+++ b/src/main/scala/com/example/models/Movie.scala
@@ -91,6 +91,21 @@ object MovieJsonProtocol extends DefaultJsonProtocol {
                 runtime.convertTo[Option[Long]],
                 tagline.convertTo[Option[String]],
                 spokenLanguages.convertTo[Option[List[Language]]])
+        case Seq(JsNumber(id), 
+              JsString(title), 
+              releaseDate, 
+              posterPath) =>
+          new Movie(id.toLong, 
+                title, 
+                releaseDate.convertTo[Option[String]], 
+                posterPath.convertTo[Option[String]],
+                None,
+                None,
+                None,
+                None,
+                None,
+                None,
+                None)
         case _ => throw new DeserializationException("Movie expected")
       }
     }

--- a/src/main/scala/com/example/models/Movie.scala
+++ b/src/main/scala/com/example/models/Movie.scala
@@ -58,56 +58,52 @@ object MovieJsonProtocol extends DefaultJsonProtocol {
     )
     
     def read(value: JsValue) = {
-      value.asJsObject.getFields("id", 
-          "title", 
-          "release_date",
-          "poster_path",
-          "overview",
-          "budget",
-          "genres",
-          "revenue",
-          "runtime",
-          "tagline",
-          "spoken_languages") match {
-        case Seq(JsNumber(id), 
-              JsString(title), 
-              releaseDate, 
-              posterPath,
-              overview,
-              budget,
-              genres,
-              revenue,
-              runtime,
-              tagline,
-              spokenLanguages) =>
-          new Movie(id.toLong, 
-                title, 
-                releaseDate.convertTo[Option[String]], 
-                posterPath.convertTo[Option[String]],
-                overview.convertTo[Option[String]],
-                budget.convertTo[Option[Long]],
-                genres.convertTo[Option[List[Genre]]],
-                revenue.convertTo[Option[Long]],
-                runtime.convertTo[Option[Long]],
-                tagline.convertTo[Option[String]],
-                spokenLanguages.convertTo[Option[List[Language]]])
-        case Seq(JsNumber(id), 
-              JsString(title), 
-              releaseDate, 
-              posterPath) =>
-          new Movie(id.toLong, 
-                title, 
-                releaseDate.convertTo[Option[String]], 
-                posterPath.convertTo[Option[String]],
-                None,
-                None,
-                None,
-                None,
-                None,
-                None,
-                None)
-        case _ => throw new DeserializationException("Movie expected")
-      }
+      val fields = value.asJsObject.fields
+      new Movie( fields.getOrElse("id", JsString("-1")).convertTo[Long],
+          fields.getOrElse("title", JsString("err no title")).convertTo[String],
+          fields.get("release_date").map(_.convertTo[String]),
+          fields.get("poster_path").map(_.convertTo[String]),
+          fields.get("overview").map(_.convertTo[String]),
+          fields.get("budget").map(_.convertTo[Long]),
+          fields.get("genres").map(_.convertTo[List[Genre]]),
+          fields.get("revenue").map(_.convertTo[Long]),
+          fields.get("runtime").map(_.convertTo[Long]),
+          fields.get("tagline").map(_.convertTo[String]),
+          fields.get("spoken_languages").map(_.convertTo[List[Language]]))
+//      value.asJsObject.getFields("id", 
+//          "title", 
+//          "release_date",
+//          "poster_path",
+//          "overview",
+//          "budget",
+//          "genres",
+//          "revenue",
+//          "runtime",
+//          "tagline",
+//          "spoken_languages") match {
+//        case Seq(JsNumber(id), 
+//              JsString(title), 
+//              releaseDate, 
+//              posterPath,
+//              overview,
+//              budget,
+//              genres,
+//              revenue,
+//              runtime,
+//              tagline,
+//              spokenLanguages) =>
+//          new Movie(id.toLong, 
+//                title, 
+//                releaseDate.convertTo[Option[String]], 
+//                posterPath.convertTo[Option[String]],
+//                overview.convertTo[Option[String]],
+//                budget.convertTo[Option[Long]],
+//                genres.convertTo[Option[List[Genre]]],
+//                revenue.convertTo[Option[Long]],
+//                runtime.convertTo[Option[Long]],
+//                tagline.convertTo[Option[String]],
+//                spokenLanguages.convertTo[Option[List[Language]]])
+//      }
     }
   }
 }

--- a/src/main/scala/com/example/models/TitleSearch.scala
+++ b/src/main/scala/com/example/models/TitleSearch.scala
@@ -1,15 +1,30 @@
 package com.example.models
 
 import spray.json.DefaultJsonProtocol
+import scala.language.implicitConversions
 
 case class TitleSearchQuery(val query: String, val page: Int = 1) extends SearchQuery
 
+case class TitleSearchResultsMovieDb(val page: Long, 
+    val results: List[MovieDb],
+    val total_pages: Long,
+    val total_results: Long)
+    
 case class TitleSearchResults(val page: Long, 
     val results: List[Movie],
     val total_pages: Long,
     val total_results: Long)
+
+object TitleSearchImplicits {
+  import com.example.models.MovieImplicits._
+  implicit def dbToModel(t: TitleSearchResultsMovieDb): TitleSearchResults = {
+    TitleSearchResults(t.page, t.results.map(MovieDbToMovie(_)), t.total_pages, t.total_results)
+  }
+  implicit def dbToModel (o: Option[TitleSearchResultsMovieDb]): Option[TitleSearchResults] = o.map(dbToModel(_))
+}
     
 object TitleSearchJsonProtocol extends DefaultJsonProtocol{
     import MovieJsonProtocol._
     implicit val titleSearchFormat = jsonFormat4(TitleSearchResults)
+    implicit val titleSearchMovieDbFormat = jsonFormat4(TitleSearchResultsMovieDb)
 }

--- a/src/main/scala/com/example/models/TitleSearch.scala
+++ b/src/main/scala/com/example/models/TitleSearch.scala
@@ -15,12 +15,11 @@ case class TitleSearchResults(val page: Long,
     val total_pages: Long,
     val total_results: Long)
 
-object TitleSearchImplicits {
-  import com.example.models.MovieImplicits._
-  implicit def dbToModel(t: TitleSearchResultsMovieDb): TitleSearchResults = {
-    TitleSearchResults(t.page, t.results.map(MovieDbToMovie(_)), t.total_pages, t.total_results)
+object TitleSearchConverter {
+  import com.example.models.MovieConverter._
+  def dbToModel(t: TitleSearchResultsMovieDb): TitleSearchResults = {
+    TitleSearchResults(t.page, t.results map toMovie, t.total_pages, t.total_results)
   }
-  implicit def dbToModel (o: Option[TitleSearchResultsMovieDb]): Option[TitleSearchResults] = o.map(dbToModel(_))
 }
     
 object TitleSearchJsonProtocol extends DefaultJsonProtocol{

--- a/src/main/scala/com/example/routes/MoviesRoute.scala
+++ b/src/main/scala/com/example/routes/MoviesRoute.scala
@@ -1,7 +1,6 @@
 package com.example.routes
 
 import org.springframework.context.annotation.Scope
-
 import com.example.config.ActorSystemBean
 import com.example.models.MovieJsonProtocol._
 import com.example.models.MovieCastJsonProtocol._
@@ -9,12 +8,13 @@ import com.example.models.TitleSearchQuery
 import com.example.models.TitleSearchJsonProtocol._
 import com.example.models.TrailersJsonProtocol._
 import com.example.services.MovieService
-
 import akka.actor.ActorLogging
 import javax.inject.Inject
 import javax.inject.Named
 import spray.httpx.SprayJsonSupport._
 import spray.routing.HttpServiceActor
+import com.example.models.TitleSearchResults
+import com.example.models.Movie
 
 @Named
 @Scope("prototype")
@@ -23,15 +23,17 @@ class MoviesRoute @Inject()(ms: MovieService, asb: ActorSystemBean) extends Http
 																	with RouteExceptionHandlers {
   
   import asb.system.dispatcher
+  import com.example.models.MovieImplicits._
+  import com.example.models.TitleSearchImplicits._
   
   def receive = runRoute {
     get {
       parameters('query, 'page ? 1).as(TitleSearchQuery) { query =>
-	    val titleSearchResults = ms.getTitleSearchResults(query)
+	    val titleSearchResults : Option[TitleSearchResults] = ms.getTitleSearchResults(query)
 	    complete(titleSearchResults) 
       }~
 	  path(LongNumber) { movieId =>  
-		val movie = ms.getMovie(movieId)
+		val movie : Option[Movie] = ms.getMovie(movieId)
 		complete(movie)
 	  }~
 	  path(LongNumber / "cast") { movieId =>

--- a/src/main/scala/com/example/routes/MoviesRoute.scala
+++ b/src/main/scala/com/example/routes/MoviesRoute.scala
@@ -1,6 +1,7 @@
 package com.example.routes
 
 import org.springframework.context.annotation.Scope
+
 import com.example.config.ActorSystemBean
 import com.example.models.MovieJsonProtocol._
 import com.example.models.MovieCastJsonProtocol._
@@ -8,13 +9,13 @@ import com.example.models.TitleSearchQuery
 import com.example.models.TitleSearchJsonProtocol._
 import com.example.models.TrailersJsonProtocol._
 import com.example.services.MovieService
+
 import akka.actor.ActorLogging
 import javax.inject.Inject
 import javax.inject.Named
 import spray.httpx.SprayJsonSupport._
 import spray.routing.HttpServiceActor
-import com.example.models.TitleSearchResults
-import com.example.models.Movie
+
 
 @Named
 @Scope("prototype")
@@ -23,17 +24,15 @@ class MoviesRoute @Inject()(ms: MovieService, asb: ActorSystemBean) extends Http
 																	with RouteExceptionHandlers {
   
   import asb.system.dispatcher
-  import com.example.models.MovieImplicits._
-  import com.example.models.TitleSearchImplicits._
   
   def receive = runRoute {
     get {
       parameters('query, 'page ? 1).as(TitleSearchQuery) { query =>
-	    val titleSearchResults : Option[TitleSearchResults] = ms.getTitleSearchResults(query)
+	    val titleSearchResults = ms.getTitleSearchResults(query)
 	    complete(titleSearchResults) 
       }~
 	  path(LongNumber) { movieId =>  
-		val movie : Option[Movie] = ms.getMovie(movieId)
+		val movie = ms.getMovie(movieId)
 		complete(movie)
 	  }~
 	  path(LongNumber / "cast") { movieId =>

--- a/src/main/scala/com/example/routes/RouteExceptionHandlers.scala
+++ b/src/main/scala/com/example/routes/RouteExceptionHandlers.scala
@@ -19,7 +19,7 @@ trait RouteExceptionHandlers extends HttpService {
     case t: Throwable =>
       requestUri { uri =>
         log.warning("Request to {} could not be handled normally", uri)
-        complete(StatusCodes.InternalServerError, "Wouldn't you like to know what happened?")
+        complete(StatusCodes.InternalServerError, "Wouldn't you like to know what happened?" + t)
       }  
   }    
 

--- a/src/main/scala/com/example/routes/RouteRejectionHandlers.scala
+++ b/src/main/scala/com/example/routes/RouteRejectionHandlers.scala
@@ -10,8 +10,8 @@ import spray.routing.RejectionHandler
 trait RouteRejectionHandlers extends HttpService {
   
   implicit val myRejectionHandler = RejectionHandler {
-    case MissingCookieRejection(_) :: _ => redirect("http://localhost:8080/login", StatusCodes.TemporaryRedirect)
-    case AuthorizationFailedRejection :: _ => redirect("http://localhost:8080/login", StatusCodes.TemporaryRedirect)
+    case MissingCookieRejection(_) :: _ => redirect("/login", StatusCodes.TemporaryRedirect)
+    case AuthorizationFailedRejection :: _ => redirect("/login", StatusCodes.TemporaryRedirect)
   } 
 
 }

--- a/src/main/scala/com/example/services/MovieService.scala
+++ b/src/main/scala/com/example/services/MovieService.scala
@@ -1,16 +1,16 @@
 package com.example.services
 
+import com.example.models.Movie
 import com.example.models.MovieCast
 import com.example.models.TitleSearchQuery
+import com.example.models.TitleSearchResults
 import com.example.models.Trailers
-import com.example.models.TitleSearchResultsMovieDb
-import com.example.models.MovieDb
 
 trait MovieService {
   
-  def getMovie(movieId: Long): Option[MovieDb]
+  def getMovie(movieId: Long): Option[Movie]
   def getMovieCast(movieId: Long): Option[MovieCast]
   def getTrailers(movieId: Long): Option[Trailers]
-  def getTitleSearchResults(query: TitleSearchQuery): Option[TitleSearchResultsMovieDb]
+  def getTitleSearchResults(query: TitleSearchQuery): Option[TitleSearchResults]
 
 }

--- a/src/main/scala/com/example/services/MovieService.scala
+++ b/src/main/scala/com/example/services/MovieService.scala
@@ -1,16 +1,16 @@
 package com.example.services
 
-import com.example.models.Movie
 import com.example.models.MovieCast
 import com.example.models.TitleSearchQuery
-import com.example.models.TitleSearchResults
 import com.example.models.Trailers
+import com.example.models.TitleSearchResultsMovieDb
+import com.example.models.MovieDb
 
 trait MovieService {
   
-  def getMovie(movieId: Long): Option[Movie]
+  def getMovie(movieId: Long): Option[MovieDb]
   def getMovieCast(movieId: Long): Option[MovieCast]
   def getTrailers(movieId: Long): Option[Trailers]
-  def getTitleSearchResults(query: TitleSearchQuery): Option[TitleSearchResults]
+  def getTitleSearchResults(query: TitleSearchQuery): Option[TitleSearchResultsMovieDb]
 
 }

--- a/src/main/scala/com/example/services/MovieServiceImpl.scala
+++ b/src/main/scala/com/example/services/MovieServiceImpl.scala
@@ -3,25 +3,23 @@ package com.example.services
 import scala.concurrent.Await
 import scala.concurrent.duration.DurationInt
 import scala.language.postfixOps
-
 import com.example.config.ActorSystemBean
-import com.example.models.Movie
 import com.example.models.MovieCast
 import com.example.models.MovieCastJsonProtocol._
 import com.example.models.MovieJsonProtocol._
 import com.example.models.TitleSearchJsonProtocol._
 import com.example.models.TitleSearchQuery
-import com.example.models.TitleSearchResults
 import com.example.models.Trailers
 import com.example.models.TrailersJsonProtocol._
 import com.example.util.GlobalConstants.API_KEY_QUERY_PARAM
-
 import javax.inject.Inject
 import javax.inject.Named
 import spray.client.pipelining._
 import spray.http.HttpHeaders.Host
 import spray.http.HttpRequest
 import spray.httpx.SprayJsonSupport._
+import com.example.models.MovieDb
+import com.example.models.TitleSearchResultsMovieDb
 
 @Named
 class MovieServiceImpl @Inject()(asb: ActorSystemBean) extends MovieService {
@@ -33,12 +31,12 @@ class MovieServiceImpl @Inject()(asb: ActorSystemBean) extends MovieService {
     request.withEffectiveUri(false, Host("api.themoviedb.org", 80)) ~> sendReceive
   }
   
-  def getMovie(movieId: Long): Option[Movie] = {
-	val pipeline = defaultRequest ~> unmarshal[Option[Movie]]
+  def getMovie(movieId: Long): Option[MovieDb] = {
+	val pipeline = defaultRequest ~> unmarshal[Option[MovieDb]]
 	val responseFuture = pipeline {
 	  Get("/3/movie/" + movieId + API_KEY_QUERY_PARAM)
 	}
-	Await.result(responseFuture.mapTo[Option[Movie]], 5 seconds)
+	Await.result(responseFuture.mapTo[Option[MovieDb]], 5 seconds)
   }
   
   def getMovieCast(movieId: Long): Option[MovieCast] = {
@@ -57,12 +55,12 @@ class MovieServiceImpl @Inject()(asb: ActorSystemBean) extends MovieService {
 	Await.result(responseFuture.mapTo[Option[Trailers]], 5 seconds)    
   }  
   
-  def getTitleSearchResults(query: TitleSearchQuery): Option[TitleSearchResults] = {
-    val pipeline = defaultRequest ~> unmarshal[Option[TitleSearchResults]]
+  def getTitleSearchResults(query: TitleSearchQuery): Option[TitleSearchResultsMovieDb] = {
+    val pipeline = defaultRequest ~> unmarshal[Option[TitleSearchResultsMovieDb]]
     val responseFuture = pipeline {
 	  Get("/3/search/movie" + API_KEY_QUERY_PARAM + query.queryParamsAmpPrefix)
 	}
-	Await.result(responseFuture.mapTo[Option[TitleSearchResults]], 5 seconds)      
+	Await.result(responseFuture.mapTo[Option[TitleSearchResultsMovieDb]], 5 seconds)      
   }
   
 }

--- a/src/main/scala/com/example/services/MovieServiceImpl.scala
+++ b/src/main/scala/com/example/services/MovieServiceImpl.scala
@@ -18,8 +18,14 @@ import spray.client.pipelining._
 import spray.http.HttpHeaders.Host
 import spray.http.HttpRequest
 import spray.httpx.SprayJsonSupport._
+import com.example.models.Movie
 import com.example.models.MovieDb
+import com.example.models.TitleSearchResults
 import com.example.models.TitleSearchResultsMovieDb
+import com.example.models.MovieConverter._
+import com.example.models.TitleSearchConverter._
+import org.slf4j.LoggerFactory
+import spray.http.HttpResponse
 
 @Named
 class MovieServiceImpl @Inject()(asb: ActorSystemBean) extends MovieService {
@@ -27,16 +33,19 @@ class MovieServiceImpl @Inject()(asb: ActorSystemBean) extends MovieService {
   import asb._ // make the implicit ActorSystem available for sendRecieve
   import asb.system.dispatcher // execution context for futures 
   
+  val log = LoggerFactory.getLogger(classOf[MovieServiceImpl])
+  
+  val logResponse: HttpResponse => HttpResponse = { r => log.debug(r.entity.toString); r } 
   protected def defaultRequest = { request: HttpRequest =>
     request.withEffectiveUri(false, Host("api.themoviedb.org", 80)) ~> sendReceive
   }
   
-  def getMovie(movieId: Long): Option[MovieDb] = {
-	val pipeline = defaultRequest ~> unmarshal[Option[MovieDb]]
+  def getMovie(movieId: Long): Option[Movie] = {
+	val pipeline = defaultRequest ~> logResponse ~> unmarshal[Option[MovieDb]]
 	val responseFuture = pipeline {
 	  Get("/3/movie/" + movieId + API_KEY_QUERY_PARAM)
 	}
-	Await.result(responseFuture.mapTo[Option[MovieDb]], 5 seconds)
+	Await.result(responseFuture.mapTo[Option[MovieDb]], 5 seconds) map toMovie 
   }
   
   def getMovieCast(movieId: Long): Option[MovieCast] = {
@@ -55,12 +64,12 @@ class MovieServiceImpl @Inject()(asb: ActorSystemBean) extends MovieService {
 	Await.result(responseFuture.mapTo[Option[Trailers]], 5 seconds)    
   }  
   
-  def getTitleSearchResults(query: TitleSearchQuery): Option[TitleSearchResultsMovieDb] = {
+  def getTitleSearchResults(query: TitleSearchQuery): Option[TitleSearchResults] = {
     val pipeline = defaultRequest ~> unmarshal[Option[TitleSearchResultsMovieDb]]
     val responseFuture = pipeline {
 	  Get("/3/search/movie" + API_KEY_QUERY_PARAM + query.queryParamsAmpPrefix)
 	}
-	Await.result(responseFuture.mapTo[Option[TitleSearchResultsMovieDb]], 5 seconds)      
+	Await.result(responseFuture.mapTo[Option[TitleSearchResultsMovieDb]], 5 seconds) map dbToModel     
   }
   
 }


### PR DESCRIPTION
Instead of extending the RootJsonFormat to convert between how the movie is modeled in the spray-moviedb app vs how the moviedb models the movie I created a class for each model and implicit conversions between the two.